### PR TITLE
Fix for isPathParameter

### DIFF
--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -153,7 +153,7 @@ export function readFileAsStringSync(filePath: string) {
 }
 
 export function isPathParameter(pathSegment: string) {
-  return pathSegment.startsWith('{') && pathSegment.endsWith('{');
+  return pathSegment.startsWith('{') && pathSegment.endsWith('}');
 }
 
 


### PR DESCRIPTION
## What/Why/How?
`isPathParameter` failed due to a wrong brace. Trivial patch.